### PR TITLE
Typo on the getPlain method call

### DIFF
--- a/src/APIClient.php
+++ b/src/APIClient.php
@@ -304,7 +304,7 @@ class APIClient
         $curl = curl_init($this->socketURL);
         $data = $this->getPOSTData($cmd);
         if ($curl === false) {
-            $r = RTM::getInstance()->getTemplate("nocurl").getPlain();
+            $r = RTM::getInstance()->getTemplate("nocurl")->getPlain();
             if ($this->debugMode) {
                 echo $this->socketURL . "\n";
                 echo $data . "\n";
@@ -331,7 +331,7 @@ class APIClient
         ));
         $r = curl_exec($curl);
         $r = ($r===false) ?
-            RTM::getInstance()->getTemplate("httperror").getPlain() :
+            RTM::getInstance()->getTemplate("httperror")->getPlain() :
             //gzdecode($r);
             $r;
 


### PR DESCRIPTION
I found some errors in my integration and discovered this problem in the **getPlain** method call.

A question: is there a time limit between two API calls? I had to put a sleep of 500 milliseconds, otherwise after a few hundred calls there started to be a lot of http errors (and from here I discovered the typo in the class).